### PR TITLE
feat: 新增,支持不通gitlab服务器对应的不同机器人地址的配置

### DIFF
--- a/api.py
+++ b/api.py
@@ -190,6 +190,7 @@ def __handle_push_event(webhook_data: dict, gitlab_token: str, gitlab_url: str):
             changes = filter_changes(changes)
             if not changes:
                 logger.info('未检测到PUSH代码的修改,修改文件可能不满足SUPPORTED_EXTENSIONS。')
+                return
             review_result = "关注的文件没有修改"
 
             if len(changes) > 0:
@@ -249,6 +250,10 @@ def __handle_merge_request_event(webhook_data: dict, gitlab_token: str, gitlab_u
             # review 代码
             commits_text = ';'.join(commit['title'] for commit in commits)
             review_result = review_code(str(changes), commits_text)
+
+            if "COT ABORT!" in review_result:
+                logger.error('COT ABORT!')
+                return
 
             # 将review结果提交到Gitlab的 notes
             handler.add_merge_request_notes(f'Auto Review Result: \n{review_result}')

--- a/api.py
+++ b/api.py
@@ -266,7 +266,7 @@ def __handle_merge_request_event(webhook_data: dict, gitlab_token: str, gitlab_u
                     score=CodeReviewer.parse_review_score(review_text=review_result),
                     url=webhook_data['object_attributes']['url'],
                     review_result=review_result,
-                    gitlab_url = gitlab_url,
+                    gitlab_url = url_base,
                 )
             )
 

--- a/biz/entity/review_entity.py
+++ b/biz/entity/review_entity.py
@@ -1,6 +1,6 @@
 class MergeRequestReviewEntity:
     def __init__(self, project_name: str, author: str, source_branch: str, target_branch: str, updated_at: int,
-                 commits: list, score: float, url: str, review_result: str):
+                 commits: list, score: float, url: str, review_result: str, gitlab_url: str):
         self.project_name = project_name
         self.author = author
         self.source_branch = source_branch
@@ -10,6 +10,7 @@ class MergeRequestReviewEntity:
         self.score = score
         self.url = url
         self.review_result = review_result
+        self.gitlab_url = gitlab_url
 
     @property
     def commit_messages(self):
@@ -19,7 +20,7 @@ class MergeRequestReviewEntity:
 
 class PushReviewEntity:
     def __init__(self, project_name: str, author: str, branch: str, updated_at: int, commits: list, score: float,
-                 review_result: str):
+                 review_result: str, gitlab_url: str):
         self.project_name = project_name
         self.author = author
         self.branch = branch
@@ -27,6 +28,7 @@ class PushReviewEntity:
         self.commits = commits
         self.score = score
         self.review_result = review_result
+        self.gitlab_url = gitlab_url
 
     @property
     def commit_messages(self):

--- a/biz/event/event_manager.py
+++ b/biz/event/event_manager.py
@@ -32,7 +32,7 @@ def on_merge_request_reviewed(mr_review_entity: MergeRequestReviewEntity):
 {mr_review_entity.review_result}
     """
     im_notifier.send_notification(content=im_msg, msg_type='markdown', title='Merge Request Review',
-                                  project_name=mr_review_entity.project_name)
+                                  project_name=mr_review_entity.project_name, url_base=mr_review_entity.gitlab_url)
 
     # 记录到数据库
     ReviewService().insert_mr_review_log(mr_review_entity)
@@ -58,7 +58,7 @@ def on_push_reviewed(entity: PushReviewEntity):
     if entity.review_result:
         im_msg += f"#### AI Review 结果: \n {entity.review_result}\n\n"
     im_notifier.send_notification(content=im_msg, msg_type='markdown',
-                                  title=f"{entity.project_name} Push Event", project_name=entity.project_name)
+                                  title=f"{entity.project_name} Push Event", project_name=entity.project_name, url_base=entity.gitlab_url)
 
     # 记录到数据库
     ReviewService().insert_push_review_log(entity)

--- a/biz/utils/im/dingtalk.py
+++ b/biz/utils/im/dingtalk.py
@@ -16,7 +16,7 @@ class DingTalkNotifier:
         self.enabled = os.environ.get('DINGTALK_ENABLED', '0') == '1'
         self.default_webhook_url = webhook_url or os.environ.get('DINGTALK_WEBHOOK_URL')
 
-    def _get_webhook_url(self, project_name=None):
+    def _get_webhook_url(self, project_name=None, url_base=None):
         """
         获取项目对应的 Webhook URL
         :param project_name: 项目名称
@@ -35,6 +35,12 @@ class DingTalkNotifier:
         for env_key, env_value in os.environ.items():
             if env_key.upper() == target_key:
                 return env_value  # 找到匹配项，直接返回
+            
+        # url_base 优先级次之
+        target_key_url_base = f"WECOM_WEBHOOK_URL_{url_base.upper()}"
+        for env_key, env_value in os.environ.items():
+            if target_key_url_base !=None and  env_key.upper() == target_key_url_base:
+                return env_value  # 找到匹配项，直接返回
 
         # 如果未找到匹配的环境变量，降级使用全局的 Webhook URL
         if self.default_webhook_url:
@@ -43,13 +49,13 @@ class DingTalkNotifier:
         # 如果既未找到匹配项，也没有默认值，抛出异常
         raise ValueError(f"未找到项目 '{project_name}' 对应的钉钉Webhook URL，且未设置默认的 Webhook URL。")
 
-    def send_message(self, content: str, msg_type='text', title='通知', is_at_all=False, project_name=None):
+    def send_message(self, content: str, msg_type='text', title='通知', is_at_all=False, project_name=None, url_base = None):
         if not self.enabled:
             logger.info("钉钉推送未启用")
             return
 
         try:
-            post_url = self._get_webhook_url(project_name=project_name)
+            post_url = self._get_webhook_url(project_name=project_name, url_base=url_base)
             headers = {
                 "Content-Type": "application/json",
                 "Charset": "UTF-8"

--- a/biz/utils/im/feishu.py
+++ b/biz/utils/im/feishu.py
@@ -14,7 +14,7 @@ class FeishuNotifier:
         self.default_webhook_url = webhook_url or os.environ.get('FEISHU_WEBHOOK_URL', '')
         self.enabled = os.environ.get('FEISHU_ENABLED', '0') == '1'
 
-    def _get_webhook_url(self, project_name=None):
+    def _get_webhook_url(self, project_name=None, url_base=None):
         """
         获取项目对应的 Webhook URL
         :param project_name: 项目名称
@@ -33,6 +33,12 @@ class FeishuNotifier:
         for env_key, env_value in os.environ.items():
             if env_key.upper() == target_key:
                 return env_value  # 找到匹配项，直接返回
+            
+        # url_base 优先级次之
+        target_key_url_base = f"WECOM_WEBHOOK_URL_{url_base.upper()}"
+        for env_key, env_value in os.environ.items():
+            if target_key_url_base !=None and  env_key.upper() == target_key_url_base:
+                return env_value  # 找到匹配项，直接返回
 
         # 如果未找到匹配的环境变量，降级使用全局的 Webhook URL
         if self.default_webhook_url:
@@ -41,7 +47,7 @@ class FeishuNotifier:
         # 如果既未找到匹配项，也没有默认值，抛出异常
         raise ValueError(f"未找到项目 '{project_name}' 对应的 Feishu Webhook URL，且未设置默认的 Webhook URL。")
 
-    def send_message(self, content, msg_type='text', title=None, is_at_all=False, project_name=None):
+    def send_message(self, content, msg_type='text', title=None, is_at_all=False, project_name=None, url_base=None):
         """
         发送飞书消息
         :param content: 消息内容
@@ -55,7 +61,7 @@ class FeishuNotifier:
             return
 
         try:
-            post_url = self._get_webhook_url(project_name=project_name)
+            post_url = self._get_webhook_url(project_name=project_name, url_base=url_base)
             if msg_type == 'markdown':
                 data = {
                     "msg_type": "interactive",

--- a/biz/utils/im/im_notifier.py
+++ b/biz/utils/im/im_notifier.py
@@ -3,25 +3,26 @@ from biz.utils.im.feishu import FeishuNotifier
 from biz.utils.im.wecom import WeComNotifier
 
 
-def send_notification(content, msg_type='text', title="通知", is_at_all=False, project_name=None):
+def send_notification(content, msg_type='text', title="通知", is_at_all=False, project_name=None, url_base=None):
     """
     发送通知消息到配置的平台(钉钉和企业微信)
     :param content: 消息内容
     :param msg_type: 消息类型，支持text和markdown
     :param title: 消息标题(markdown类型时使用)
     :param is_at_all: 是否@所有人
+    :param url_base: gitlab服务器的url地址 http://www.gitlab.com 传递进来自动移除http和https，转换成 www_gitlab_com
     """
     # 钉钉推送
     notifier = DingTalkNotifier()
     notifier.send_message(content=content, msg_type=msg_type, title=title, is_at_all=is_at_all,
-                          project_name=project_name)
+                          project_name=project_name, url_base=url_base)
 
     # 企业微信推送
     wecom_notifier = WeComNotifier()
     wecom_notifier.send_message(content=content, msg_type=msg_type, title=title, is_at_all=is_at_all,
-                                project_name=project_name)
+                                project_name=project_name, url_base=url_base)
 
     # 飞书推送
     feishu_notifier = FeishuNotifier()
     feishu_notifier.send_message(content=content, msg_type=msg_type, title=title, is_at_all=is_at_all,
-                                 project_name=project_name)
+                                 project_name=project_name, url_base=url_base)

--- a/core/llm/client/ollama_client.py
+++ b/core/llm/client/ollama_client.py
@@ -29,6 +29,9 @@ class OllamaClient(BaseClient):
         """
         if re.search(r'<think>.*?</think>', content, re.DOTALL):
             return re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
+        elif "<think>" in content and "</think>" not in content:
+            # 大模型回复的时候，思考链有可能截断，那么果断忽略回复，返回空
+            return "COT ABORT!"
         return content
 
     def completions(self,

--- a/core/llm/client/ollama_client.py
+++ b/core/llm/client/ollama_client.py
@@ -27,11 +27,13 @@ class OllamaClient(BaseClient):
         Returns:
             str: 提取后的内容。
         """
-        if re.search(r'<think>.*?</think>', content, re.DOTALL):
-            return re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
-        elif "<think>" in content and "</think>" not in content:
+        if "<think>" in content and "</think>" not in content:
             # 大模型回复的时候，思考链有可能截断，那么果断忽略回复，返回空
             return "COT ABORT!"
+        elif "<think>" not in content and "</think>" in content:
+            return content.split("</think>", 1)[1].strip()
+        elif re.search(r'<think>.*?</think>', content, re.DOTALL):
+            return re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL).strip()
         return content
 
     def completions(self,

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -67,3 +67,18 @@ DINGTALK_WEBHOOK_URL=https://oapi.dingtalk.com/robot/send?access_token={access_t
 OLLAMA_API_BASE_URL=http://127.0.0.1:11434  # 错误
 OLLAMA_API_BASE_URL=http://{宿主机/外网IP地址}:11434  # 正确
 ```
+
+#### 5.如何支持多个git服务器及对应的不通webhook地址
+
+在项目的 .env 文件中，配置不同GIT项目对应的群机器人的 Webhook 地址。替换
+以 DingTalk 为例，配置如下：
+
+```
+DINGTALK_ENABLED=1
+# git服务器A实际地址 http://192.168.30.164/
+DINGTALK_WEBHOOK_192_168_30_164=https://oapi.dingtalk.com/robot/send?access_token={access_token_of_project_a}
+# git服务器A实际地址 http://192.168.35.164/
+DINGTALK_WEBHOOK_192_168_35_164=https://oapi.dingtalk.com/robot/send?access_token={access_token_of_project_a}
+```
+
+飞书和企业微信的配置方式类似，GIT服务器的群机器人优先级，仓库名字>特定服务器地址>默认服务器地址


### PR DESCRIPTION

#### 5.如何支持多个git服务器及对应的不通webhook地址

在项目的 .env 文件中，配置不同GIT项目对应的群机器人的 Webhook 地址。替换
以 DingTalk 为例，配置如下：

```
DINGTALK_ENABLED=1
# git服务器A实际地址 http://192.168.30.164/
DINGTALK_WEBHOOK_192_168_30_164=https://oapi.dingtalk.com/robot/send?access_token={access_token_of_project_a}
# git服务器A实际地址 http://192.168.35.164/
DINGTALK_WEBHOOK_192_168_35_164=https://oapi.dingtalk.com/robot/send?access_token={access_token_of_project_a}
```

飞书和企业微信的配置方式类似，GIT服务器的群机器人优先级，仓库名字>特定服务器地址>默认服务器地址
