### PR TITLE
fix: correctly use worker

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -45,6 +45,17 @@ jobs:
             type=semver,pattern={{major}}
             type=edge,branch=main
 
+      - name: Extract metadata (tags, labels) for Docker (worker)
+        id: meta_worker
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-worker
+            type=semver,pattern={{major}}.{{minor}},suffix=-worker
+            type=semver,pattern={{major}},suffix=-worker
+            type=edge,branch=main,suffix=-worker
+
       # Build and push multi-arch prod image
       - name: Build and push prod Docker image (Multi-Arch)
         uses: docker/build-push-action@v6
@@ -56,3 +67,15 @@ jobs:
           tags: ${{ steps.meta_prod.outputs.tags }}
           labels: ${{ steps.meta_prod.outputs.labels }}
           target: prod
+
+      # Build and push multi-arch worker image
+      - name: Build and push worker Docker image (Multi-Arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64/v8
+          tags: ${{ steps.meta_worker.outputs.tags }}
+          labels: ${{ steps.meta_worker.outputs.labels }}
+          target: worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,18 @@ COPY api.py ./api.py
 COPY ui.py ./ui.py
 COPY conf/prompt_templates.yml ./conf/prompt_templates.yml
 
-# 暴露 Flask 和 Streamlit 的端口
-EXPOSE 5001 5002
-
 # 使用 supervisord 作为启动命令
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 FROM base AS dev
 COPY ./conf/supervisord.dev.conf /etc/supervisor/conf.d/supervisord.conf
+# 暴露 Flask 和 Streamlit 的端口
+EXPOSE 5001 5002
 
 FROM base AS prod
 COPY ./conf/supervisord.prod.conf /etc/supervisor/conf.d/supervisord.conf
+# 暴露 Flask 和 Streamlit 的端口
+EXPOSE 5001 5002
 
 FROM base AS worker
 COPY ./conf/supervisord.worker.conf /etc/supervisor/conf.d/supervisord.conf

--- a/conf/supervisord.worker.conf
+++ b/conf/supervisord.worker.conf
@@ -3,8 +3,7 @@ nodaemon=true
 user=root
 
 [program:worker]
-#command=rq worker %(ENV_WORKER_QUEUE)s --url redis://redis:6379 --path /app
-command=rq worker gitlab_yj_edusoho_cn --url redis://redis:6379 --path /app
+command=rq worker %(ENV_WORKER_QUEUE)s --url redis://redis:6379 --path /app
 autostart=true
 autorestart=true
 numprocs=1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: worker
-    # image: sunmh207/ai-codereview-gitlab:1.3.1-worker
+    image: sunmh207/ai-codereview-gitlab:1.3.1-worker
     volumes_from:
       - app
     env_file:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: worker
-    image: sunmh207/ai-codereview-gitlab:1.3.1-worker
+    image: ghcr.io/sunmh207/ai-codereview-gitlab:1.3.1-worker
     volumes_from:
       - app
     env_file:
@@ -42,7 +42,7 @@ services:
 #      context: .
 #      dockerfile: Dockerfile
 #      target: worker
-#    # image: sunmh207/ai-codereview-gitlab:1.3.1-worker
+#    image: ghcr.io/sunmh207/ai-codereview-gitlab:1.3.1-worker
 #    volumes_from:
 #      - app
 #    env_file:
@@ -57,8 +57,6 @@ services:
 
   redis:
     image: redis:alpine
-#    ports:
-#      - "${REDIS_PORT}:6379"
     volumes:
       - redis_data:/data
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     volumes:
       - ./biz:/app/biz
       - ./conf:/app/conf
-      - ./conf/supervisord.dev.conf:/etc/supervisor/conf.d/supervisord.conf
       - ./data:/app/data
       - ./log:/app/log
       - ./api.py:/app/api.py
@@ -29,7 +28,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: worker
-    # image: sunmh207/ai-codereview-gitlab:1.2.3-worker
+    image: ghcr.io/sunmh207/ai-codereview-gitlab:1.3.1-worker
     volumes_from:
       - app
     env_file:
@@ -41,8 +40,6 @@ services:
 
   redis:
     image: redis:alpine
-    env_file:
-      - ./conf/.env
     ports:
       - "6379:6379"
     volumes:


### PR DESCRIPTION
I probably forgot to backport these fixes from my main to the feature branch in the PR, sorry for that.

Features:
- add multi-stage docker image build for Github actions

Fixes (tested & working):
- use separate docker image names for docker compose for app and worker
- remove mount for supervisor dev file from app container as volumes are inherited to worker process
- move definition to expose ports to dev and prod container, not worker
- use env var again for worker supervisor config

Keep in mind to set these env vars in your .env file (again), then restart your containers:
- `WORKER_QUEUE= gitlab_yj_edusoho_cn`
- `OLLAMA_API_BASE_URL=http://host.docker.internal:11434`