### PR TITLE
[Fix]: correctly implement webhook secret for both github and gitlab

### DIFF
--- a/biz/utils/webhook_secret_checker.py
+++ b/biz/utils/webhook_secret_checker.py
@@ -1,0 +1,34 @@
+import hashlib
+import hmac
+from http.client import HTTPException
+
+
+# from https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries#python-example
+def verify_github_signature(payload_body, secret_token, signature_header):
+    """Verify that the payload was sent from GitHub by validating SHA256.
+
+    Raise and return 403 if not authorized.
+
+    Args:
+        payload_body: original request body to verify (request.body())
+        secret_token: GitHub app webhook token (WEBHOOK_SECRET)
+        signature_header: header received from GitHub (x-hub-signature-256)
+    """
+    # 仅当设置了环境变量时才验证秘密令牌
+    if not secret_token:
+        return True
+    if not signature_header:
+        raise HTTPException(status_code=403, detail="x-hub-signature-256 header is missing!")
+    hash_object = hmac.new(secret_token.encode('utf-8'), msg=payload_body, digestmod=hashlib.sha256)
+    expected_signature = "sha256=" + hash_object.hexdigest()
+    if not hmac.compare_digest(expected_signature, signature_header):
+        raise HTTPException(status_code=403, detail="Request signatures didn't match!")
+    return True
+
+
+def verify_gitlab_webhook_secret_token(secret_token_env, secret_token_request):
+    # 仅当设置了环境变量时才验证秘密令牌
+    if secret_token_env:
+        if secret_token_env != secret_token_request:
+            return False
+    return True

--- a/conf/.env.dist
+++ b/conf/.env.dist
@@ -55,9 +55,11 @@ REPORT_CRONTAB_EXPRESSION=0 18 * * 1-5
 #Gitlab配置
 #GITLAB_URL={YOUR_GITLAB_URL} #部分老版本Gitlab webhook不传递URL，需要开启此配置，示例：https://gitlab.example.com
 #GITLAB_ACCESS_TOKEN={YOUR_GITLAB_ACCESS_TOKEN} #系统会优先使用此GITLAB_ACCESS_TOKEN，如果未配置，则使用Webhook 传递的Secret Token
+#GITLAB_WEBHOOK_SECRET_TOKEN={YOUR_GITLAB_WEBHOOK_SECRET_TOKEN} #在 webhook 中使用相同的秘密令牌来验证其签名
 
 #Github配置(如果使用 Github 作为代码托管平台，需要配置此项)
 #GITHUB_ACCESS_TOKEN={YOUR_GITHUB_ACCESS_TOKEN}
+#GITHUB_WEBHOOK_SECRET_TOKEN={YOUR_GITHUB_WEBHOOK_SECRET_TOKEN} #在 webhook 中使用相同的秘密令牌来验证其签名
 
 # 开启Push Review功能(如果不需要push事件触发Code Review，设置为0)
 PUSH_REVIEW_ENABLED=1


### PR DESCRIPTION
Currently the webhook secret token is implemented as alternative to the access token env var(s).

Sending raw passwords or tokens in headers—even over HTTPS—poses risks because these headers can be logged or exposed during debugging and processing, e.g. in firewalls, logs, Man-in-the-middle attacks etc. HTTPS secures data in transit but doesn’t protect the endpoints, making any sensitive token vulnerable if misconfigured or mishandled. Additionally, using a raw password or full token violates the principle of least privilege, as it provides broader access than necessary, increasing the attack surface.

The new implementation mitigates these risks by separating the trusted secret stored in an environment variable from the token received in the request header and then verifying the data in a dedicated function. This approach not only limits the scope and lifetime of the token but also isolates the verification logic to prevent accidental logging or exposure, ultimately providing a more secure method for authenticating between systems.

I've also implemented the reference signature check from https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries#python-example, which you can find now in `webhook_secret_checker.py`.

Happy to support on further questions!