### PR TITLE
Fix the issue of being unable to read the SUPPORTED_EXTENSIONS enviro…

### DIFF
--- a/biz/github/webhook_handler.py
+++ b/biz/github/webhook_handler.py
@@ -7,8 +7,6 @@ import requests
 
 from biz.utils.log import logger
 
-# 从环境变量中获取支持的文件扩展名
-SUPPORTED_EXTENSIONS = os.getenv('SUPPORTED_EXTENSIONS', '.java,.py,.php').split(',')
 
 
 def filter_changes(changes: list):
@@ -16,6 +14,9 @@ def filter_changes(changes: list):
     过滤数据，只保留支持的文件类型以及必要的字段信息
     专门处理GitHub格式的变更
     '''
+    # 从环境变量中获取支持的文件扩展名
+    supported_extensions = os.getenv('SUPPORTED_EXTENSIONS', '.java,.py,.php').split(',')
+    
     # 筛选出未被删除的文件
     not_deleted_changes = []
     for change in changes:
@@ -37,7 +38,7 @@ def filter_changes(changes: list):
                     
         not_deleted_changes.append(change)
     
-    logger.info(f"SUPPORTED_EXTENSIONS: {SUPPORTED_EXTENSIONS}")
+    logger.info(f"SUPPORTED_EXTENSIONS: {supported_extensions}")
     logger.info(f"After filtering deleted files: {not_deleted_changes}")
     
     # 过滤 `new_path` 以支持的扩展名结尾的元素, 仅保留diff和new_path字段
@@ -47,7 +48,7 @@ def filter_changes(changes: list):
             'new_path': item['new_path']
         }
         for item in not_deleted_changes
-        if any(item.get('new_path', '').endswith(ext) for ext in SUPPORTED_EXTENSIONS)
+        if any(item.get('new_path', '').endswith(ext) for ext in supported_extensions)
     ]
     logger.info(f"After filtering by extension: {filtered_changes}")
     return filtered_changes

--- a/biz/gitlab/webhook_handler.py
+++ b/biz/gitlab/webhook_handler.py
@@ -7,14 +7,14 @@ import requests
 
 from biz.utils.log import logger
 
-# 从环境变量中获取支持的文件扩展名
-SUPPORTED_EXTENSIONS = os.getenv('SUPPORTED_EXTENSIONS', '.java,.py,.php').split(',')
-
 
 def filter_changes(changes: list):
     '''
     过滤数据，只保留支持的文件类型以及必要的字段信息
     '''
+    # 从环境变量中获取支持的文件扩展名
+    supported_extensions = os.getenv('SUPPORTED_EXTENSIONS', '.java,.py,.php').split(',')
+
     filter_deleted_files_changes = [change for change in changes if change.get("deleted_file") == False]
 
     # 过滤 `new_path` 以支持的扩展名结尾的元素, 仅保留diff和new_path字段
@@ -24,7 +24,7 @@ def filter_changes(changes: list):
             'new_path': item['new_path']
         }
         for item in filter_deleted_files_changes
-        if any(item.get('new_path', '').endswith(ext) for ext in SUPPORTED_EXTENSIONS)
+        if any(item.get('new_path', '').endswith(ext) for ext in supported_extensions)
     ]
     return filtered_changes
 


### PR DESCRIPTION
原代码中的
```python
SUPPORTED_EXTENSIONS = os.getenv('SUPPORTED_EXTENSIONS', '.java,.py,.php').split(',')
```
会先于
```python
load_dotenv("conf/.env")
```
执行，导致这里读取不到 `SUPPORTED_EXTENSIONS`
