### PR TITLE
fix: commits_text not render

### DIFF
--- a/conf/prompt_templates.yml
+++ b/conf/prompt_templates.yml
@@ -40,4 +40,4 @@ code_review_prompt:
     {diffs_text}
     
     提交历史(commits)：
-    {{commits_text}}
+    {commits_text}


### PR DESCRIPTION
biz/utils/code_reviewer.py 94行 使用 str.format 渲染 diffs_text 和 commits_text，模板中应该使用单大括号