### PR TITLE
增加Merge Request目标分支为受保护分支时才Review的开关：MERGE_REVIEW_ONLY_PROTECTED_BRAN…

### DIFF
--- a/biz/github/webhook_handler.py
+++ b/biz/github/webhook_handler.py
@@ -1,10 +1,9 @@
-import json
 import os
 import re
 import time
 
 import requests
-
+import fnmatch
 from biz.utils.log import logger
 
 
@@ -172,6 +171,22 @@ class PullRequestHandler:
         else:
             logger.error(f"Failed to add comment: {response.status_code}")
             logger.error(response.text)
+
+    def target_branch_protected(self) -> bool:
+        url = f"https://api.github.com/repos/{self.repo_full_name}/branches?protected=true"
+        headers = {
+            'Authorization': f'token {self.github_token}',
+            'Accept': 'application/vnd.github.v3+json'
+        }
+
+        response = requests.get(url, headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            target_branch = self.webhook_data['pull_request']['base']['ref']
+            return any(fnmatch.fnmatch(target_branch, item['name']) for item in data)
+        else:
+            logger.warn(f"Failed to get protected branches: {response.status_code}, {response.text}")
+            return False
 
 
 class PushHandler:

--- a/biz/queue/worker.py
+++ b/biz/queue/worker.py
@@ -66,10 +66,15 @@ def handle_merge_request_event(webhook_data: dict, gitlab_token: str, gitlab_url
     :param gitlab_url_slug:
     :return:
     '''
+    merge_review_only_protected_branches = os.environ.get('MERGE_REVIEW_ONLY_PROTECTED_BRANCHES_ENABLED', '0') == '1'
     try:
         # 解析Webhook数据
         handler = MergeRequestHandler(webhook_data, gitlab_token, gitlab_url)
         logger.info('Merge Request Hook event received')
+        # 如果开启了仅review projected branches的，判断当前目标分支是否为projected branches
+        if merge_review_only_protected_branches and not handler.target_branch_protected():
+            logger.info("Merge Request target branch not match protected branches, ignored.")
+            return
 
         if handler.action not in ['open', 'update']:
             logger.info(f"Merge Request Hook event, action={handler.action}, ignored.")
@@ -172,10 +177,15 @@ def handle_github_pull_request_event(webhook_data: dict, github_token: str, gith
     :param github_url_slug:
     :return:
     '''
+    merge_review_only_protected_branches = os.environ.get('MERGE_REVIEW_ONLY_PROTECTED_BRANCHES_ENABLED', '0') == '1'
     try:
         # 解析Webhook数据
         handler = GithubPullRequestHandler(webhook_data, github_token, github_url)
         logger.info('GitHub Pull Request event received')
+        # 如果开启了仅review projected branches的，判断当前目标分支是否为projected branches
+        if merge_review_only_protected_branches and not handler.target_branch_protected():
+            logger.info("Merge Request target branch not match protected branches, ignored.")
+            return
 
         if handler.action not in ['opened', 'synchronize']:
             logger.info(f"Pull Request Hook event, action={handler.action}, ignored.")

--- a/biz/utils/code_reviewer.py
+++ b/biz/utils/code_reviewer.py
@@ -16,7 +16,7 @@ class BaseReviewer(abc.ABC):
 
     def __init__(self, prompt_key: str):
         self.client = Factory().getClient()
-        self.prompts = self._load_prompts(prompt_key,os.getenv("REVIEW_STYLE", "professional"))
+        self.prompts = self._load_prompts(prompt_key, os.getenv("REVIEW_STYLE", "professional"))
 
     def _load_prompts(self, prompt_key: str, style="professional") -> Dict[str, Any]:
         """加载提示词配置"""

--- a/conf/.env.dist
+++ b/conf/.env.dist
@@ -68,6 +68,8 @@ REPORT_CRONTAB_EXPRESSION=0 18 * * 1-5
 
 # 开启Push Review功能(如果不需要push事件触发Code Review，设置为0)
 PUSH_REVIEW_ENABLED=1
+# 开启Merge请求过滤，过滤仅当合并目标分支是受保护分支时才Review(开启此选项请确保仓库已配置受保护分支protected branches)
+MERGE_REVIEW_ONLY_PROTECTED_BRANCHES_ENABLED=0
 
 # Dashboard登录用户名和密码
 DASHBOARD_USER=admin


### PR DESCRIPTION
增加Merge Request目标分支为受保护分支时才Review的开关。存在一种情况，从master分支merge到dev分支的情况，有必要添加一个仅保护分支才进行Review的开关。代码实现了Gitlab和Github的，Gitlab的已测试正常，Github的未测试。