### PR TITLE
feat: 添加自定webhook通知支持

### DIFF
--- a/biz/entity/review_entity.py
+++ b/biz/entity/review_entity.py
@@ -1,6 +1,6 @@
 class MergeRequestReviewEntity:
     def __init__(self, project_name: str, author: str, source_branch: str, target_branch: str, updated_at: int,
-                 commits: list, score: float, url: str, review_result: str, url_slug: str):
+                 commits: list, score: float, url: str, review_result: str, url_slug: str, webhook_data: dict):
         self.project_name = project_name
         self.author = author
         self.source_branch = source_branch
@@ -11,6 +11,7 @@ class MergeRequestReviewEntity:
         self.url = url
         self.review_result = review_result
         self.url_slug = url_slug
+        self.webhook_data = webhook_data
 
     @property
     def commit_messages(self):
@@ -20,7 +21,7 @@ class MergeRequestReviewEntity:
 
 class PushReviewEntity:
     def __init__(self, project_name: str, author: str, branch: str, updated_at: int, commits: list, score: float,
-                 review_result: str, url_slug: str):
+                 review_result: str, url_slug: str, webhook_data: dict):
         self.project_name = project_name
         self.author = author
         self.branch = branch
@@ -29,6 +30,7 @@ class PushReviewEntity:
         self.score = score
         self.review_result = review_result
         self.url_slug = url_slug
+        self.webhook_data = webhook_data
 
     @property
     def commit_messages(self):

--- a/biz/event/event_manager.py
+++ b/biz/event/event_manager.py
@@ -32,8 +32,8 @@ def on_merge_request_reviewed(mr_review_entity: MergeRequestReviewEntity):
 {mr_review_entity.review_result}
     """
     notifier.send_notification(content=im_msg, msg_type='markdown', title='Merge Request Review',
-                                  project_name=mr_review_entity.project_name,
-                                  url_slug=mr_review_entity.url_slug)
+                               project_name=mr_review_entity.project_name, url_slug=mr_review_entity.url_slug,
+                               webhook_data=mr_review_entity.webhook_data)
 
     # 记录到数据库
     ReviewService().insert_mr_review_log(mr_review_entity)
@@ -58,9 +58,9 @@ def on_push_reviewed(entity: PushReviewEntity):
 
     if entity.review_result:
         im_msg += f"#### AI Review 结果: \n {entity.review_result}\n\n"
-    notifier.send_notification(content=im_msg, msg_type='markdown',
-                                  title=f"{entity.project_name} Push Event", project_name=entity.project_name,
-                                  url_slug=entity.url_slug)
+    notifier.send_notification(content=im_msg, msg_type='markdown',title=f"{entity.project_name} Push Event",
+                               project_name=entity.project_name, url_slug=entity.url_slug,
+                               webhook_data=entity.webhook_data)
 
     # 记录到数据库
     ReviewService().insert_push_review_log(entity)

--- a/biz/queue/worker.py
+++ b/biz/queue/worker.py
@@ -49,6 +49,7 @@ def handle_push_event(webhook_data: dict, gitlab_token: str, gitlab_url: str, gi
             score=score,
             review_result=review_result,
             url_slug=gitlab_url_slug,
+            webhook_data=webhook_data,
         ))
 
     except Exception as e:
@@ -110,6 +111,7 @@ def handle_merge_request_event(webhook_data: dict, gitlab_token: str, gitlab_url
                 url=webhook_data['object_attributes']['url'],
                 review_result=review_result,
                 url_slug=gitlab_url_slug,
+                webhook_data=webhook_data,
             )
         )
 
@@ -155,6 +157,7 @@ def handle_github_push_event(webhook_data: dict, github_token: str, github_url: 
             score=score,
             review_result=review_result,
             url_slug=github_url_slug,
+            webhook_data=webhook_data,
         ))
 
     except Exception as e:
@@ -215,7 +218,8 @@ def handle_github_pull_request_event(webhook_data: dict, github_token: str, gith
                 score=CodeReviewer.parse_review_score(review_text=review_result),
                 url=webhook_data['pull_request']['html_url'],
                 review_result=review_result,
-                url_slug=github_url_slug
+                url_slug=github_url_slug,
+                webhook_data=webhook_data,
             ))
 
     except Exception as e:

--- a/biz/utils/im/feishu.py
+++ b/biz/utils/im/feishu.py
@@ -1,7 +1,5 @@
-import json
 import requests
 import os
-import re
 from biz.utils.log import logger
 
 

--- a/biz/utils/im/notifier.py
+++ b/biz/utils/im/notifier.py
@@ -1,9 +1,11 @@
 from biz.utils.im.dingtalk import DingTalkNotifier
 from biz.utils.im.feishu import FeishuNotifier
+from biz.utils.im.webhook import ExtraWebhookNotifier
 from biz.utils.im.wecom import WeComNotifier
 
 
-def send_notification(content, msg_type='text', title="通知", is_at_all=False, project_name=None, url_slug=None):
+def send_notification(content, msg_type='text', title="通知", is_at_all=False, project_name=None, url_slug=None,
+                      webhook_data: dict={}):
     """
     发送通知消息到配置的平台(钉钉和企业微信)
     :param content: 消息内容
@@ -11,11 +13,12 @@ def send_notification(content, msg_type='text', title="通知", is_at_all=False,
     :param title: 消息标题(markdown类型时使用)
     :param is_at_all: 是否@所有人
     :param url_slug: 由gitlab服务器的url地址(如:http://www.gitlab.com)转换成的slug格式，如: www_gitlab_com
+    :param webhook_data: push event、merge event的数据内容
     """
     # 钉钉推送
     dingtalk_notifier = DingTalkNotifier()
     dingtalk_notifier.send_message(content=content, msg_type=msg_type, title=title, is_at_all=is_at_all,
-                          project_name=project_name, url_slug=url_slug)
+                                   project_name=project_name, url_slug=url_slug)
 
     # 企业微信推送
     wecom_notifier = WeComNotifier()
@@ -26,3 +29,15 @@ def send_notification(content, msg_type='text', title="通知", is_at_all=False,
     feishu_notifier = FeishuNotifier()
     feishu_notifier.send_message(content=content, msg_type=msg_type, title=title, is_at_all=is_at_all,
                                  project_name=project_name, url_slug=url_slug)
+
+    # 额外自定义webhook通知
+    extra_webhook_notifier = ExtraWebhookNotifier()
+    system_data = {
+        "content": content,
+        "msg_type": msg_type,
+        "title": title,
+        "is_at_all": is_at_all,
+        "project_name": project_name,
+        "url_slug": url_slug
+    }
+    extra_webhook_notifier.send_message(system_data=system_data, webhook_data=webhook_data)

--- a/biz/utils/im/webhook.py
+++ b/biz/utils/im/webhook.py
@@ -1,0 +1,41 @@
+import os
+from biz.utils.log import logger
+import requests
+
+
+class ExtraWebhookNotifier:
+    def __init__(self, webhook_url=None):
+        """
+        初始化ExtraWebhook通知器
+        :param webhook_url: 自定义webhook地址
+        """
+        self.default_webhook_url = webhook_url or os.environ.get('EXTRA_WEBHOOK_URL', '')
+        self.enabled = os.environ.get('EXTRA_WEBHOOK_ENABLED', '0') == '1'
+
+    def send_message(self, system_data: dict, webhook_data: dict):
+        """
+        发送额外自定义webhook消息
+        :param system_data: 系统消息内容
+        :param webhook_data: github、gitlab的push event、merge event的原始数据
+        """
+        if not self.enabled:
+            logger.info("ExtraWebhook推送未启用")
+            return
+
+        try:
+            data = {
+                "ai_codereview_data": system_data,
+                "webhook_data": webhook_data
+            }
+            response = requests.post(
+                url=self.default_webhook_url,
+                json=data,
+                headers={'Content-Type': 'application/json'}
+            )
+
+            if response.status_code != 200:
+                logger.error(f"ExtraWebhook消息发送失败! webhook_url:{self.default_webhook_url}, error_msg:{response.text}")
+                return
+
+        except Exception as e:
+            logger.error(f"ExtraWebhook消息发送失败! ", e)

--- a/conf/.env.dist
+++ b/conf/.env.dist
@@ -50,6 +50,11 @@ WECOM_WEBHOOK_URL=https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx
 FEISHU_ENABLED=0
 FEISHU_WEBHOOK_URL=https://open.feishu.cn/open-apis/bot/v2/hook/xxx
 
+#自定义webhook配置，使用场景：通过飞书发送应用消息可以实现Push评审通知到提交人，在自定义webhook里可以实现各种定制通知功能
+#参数EXTRA_WEBHOOK_URL接收POST请求，data={ai_codereview_data: {}, webhook_data: {}}，ai_codereview_data为本系统通知的数据，webhook_data为原github、gitlab hook触发的数据
+EXTRA_WEBHOOK_ENABLED=0
+EXTRA_WEBHOOK_URL=https://xxx/xxx
+
 #日志配置
 LOG_FILE=log/app.log
 LOG_MAX_BYTES=10485760


### PR DESCRIPTION
自定义webhook配置，使用场景：通过飞书发送应用消息可以实现Push评审通知到提交人，在自定义webhook里可以实现各种定制通知功能