### PR TITLE
fix: 修复Gitlab推送记录存储的分支名称错误

### DIFF
--- a/biz/queue/worker.py
+++ b/biz/queue/worker.py
@@ -48,7 +48,7 @@ def handle_push_event(webhook_data: dict, gitlab_token: str, gitlab_url: str, gi
         event_manager['push_reviewed'].send(PushReviewEntity(
             project_name=webhook_data['project']['name'],
             author=webhook_data['user_username'],
-            branch=webhook_data['project']['default_branch'],
+            branch=webhook_data.get('ref', '').replace('refs/heads/', ''),
             updated_at=int(datetime.now().timestamp()),  # 当前时间
             commits=commits,
             score=score,


### PR DESCRIPTION
Gitlab当前推送记录保存的分支名称是project.default_branch，并不是当前推送的分支的名称，更正为推送的分支名称