### PR TITLE
refactor: 合并请求如果commit未变更，不重复触发CodeReview

### DIFF
--- a/biz/entity/review_entity.py
+++ b/biz/entity/review_entity.py
@@ -1,7 +1,7 @@
 class MergeRequestReviewEntity:
     def __init__(self, project_name: str, author: str, source_branch: str, target_branch: str, updated_at: int,
                  commits: list, score: float, url: str, review_result: str, url_slug: str, webhook_data: dict,
-                 additions: int, deletions: int):
+                 additions: int, deletions: int, last_commit_id: str):
         self.project_name = project_name
         self.author = author
         self.source_branch = source_branch
@@ -15,6 +15,7 @@ class MergeRequestReviewEntity:
         self.webhook_data = webhook_data
         self.additions = additions
         self.deletions = deletions
+        self.last_commit_id = last_commit_id
 
     @property
     def commit_messages(self):


### PR DESCRIPTION
Gitlab Merge Request如果修改Reviewer，也会触发Merge Request的webhook，导致重复Review，第一个消耗token，第二个有多个评论报告，不知道看哪个。。。
该PR新增last_commit_id字段，用作判断该Merge Request是否有提交更新。
<img width="3558" height="692" alt="93671bd8a45b57d56d7a2778523ed19b" src="https://github.com/user-attachments/assets/1268d2c8-b06c-4094-8b65-5d012e0ba2b0" />
