### PR TITLE
fix: BaseClient 类的 ping 方法中可能因为模型返回的 `'ok'` 字符含有换行符导致连接模型失败的错误日志

### DIFF
--- a/biz/llm/client/base.py
+++ b/biz/llm/client/base.py
@@ -12,7 +12,7 @@ class BaseClient:
         """Ping the model to check connectivity."""
         try:
             result = self.completions(messages=[{"role": "user", "content": '请仅返回 "ok"。'}])
-            return result and result == 'ok'
+            return result and result.strip() == "ok"
         except Exception:
             logger.error("尝试连接LLM失败， {e}")
             return False


### PR DESCRIPTION
如果模型返回的结果为 “ok\n” 或 “\nok”， 会被 ping 方法判定为失败并打印错误日志