### PR TITLE
feat: 支持项目定制化提示词配置

### DIFF
--- a/biz/llm/client/base.py
+++ b/biz/llm/client/base.py
@@ -13,8 +13,9 @@ class BaseClient:
         try:
             result = self.completions(messages=[{"role": "user", "content": '请仅返回 "ok"。'}])
             return result and result.strip() == "ok"
-        except Exception:
-            logger.error("尝试连接LLM失败， {e}")
+
+        except Exception as e:
+            logger.error(f'尝试连接LLM失败， {e}')
             return False
 
     @abstractmethod

--- a/biz/queue/worker.py
+++ b/biz/queue/worker.py
@@ -27,6 +27,7 @@ def handle_push_event(webhook_data: dict, gitlab_token: str, gitlab_url: str, gi
         score = 0
         additions = 0
         deletions = 0
+        project_name = webhook_data['project']['name']
         if push_review_enabled:
             # 获取PUSH的changes
             changes = handler.get_push_changes()
@@ -38,7 +39,7 @@ def handle_push_event(webhook_data: dict, gitlab_token: str, gitlab_url: str, gi
 
             if len(changes) > 0:
                 commits_text = ';'.join(commit.get('message', '').strip() for commit in commits)
-                review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text)
+                review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text, project_name)
                 score = CodeReviewer.parse_review_score(review_text=review_result)
                 for item in changes:
                     additions += item['additions']
@@ -46,19 +47,21 @@ def handle_push_event(webhook_data: dict, gitlab_token: str, gitlab_url: str, gi
             # 将review结果提交到Gitlab的 notes
             handler.add_push_notes(f'Auto Review Result: \n{review_result}')
 
-        event_manager['push_reviewed'].send(PushReviewEntity(
-            project_name=webhook_data['project']['name'],
-            author=webhook_data['user_username'],
-            branch=webhook_data.get('ref', '').replace('refs/heads/', ''),
-            updated_at=int(datetime.now().timestamp()),  # 当前时间
-            commits=commits,
-            score=score,
-            review_result=review_result,
-            url_slug=gitlab_url_slug,
-            webhook_data=webhook_data,
-            additions=additions,
-            deletions=deletions,
-        ))
+        event_manager['push_reviewed'].send(
+            PushReviewEntity(
+                project_name=project_name,
+                author=webhook_data['user_username'],
+                branch=webhook_data.get('ref', '').replace('refs/heads/', ''),
+                updated_at=int(datetime.now().timestamp()),  # 当前时间
+                commits=commits,
+                score=score,
+                review_result=review_result,
+                url_slug=gitlab_url_slug,
+                webhook_data=webhook_data,
+                additions=additions,
+                deletions=deletions,
+            )
+        )
 
     except Exception as e:
         error_message = f'服务出现未知错误: {str(e)}\n{traceback.format_exc()}'
@@ -133,7 +136,7 @@ def handle_merge_request_event(webhook_data: dict, gitlab_token: str, gitlab_url
 
         # review 代码
         commits_text = ';'.join(commit['title'] for commit in commits)
-        review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text)
+        review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text, project_name)
 
         # 将review结果提交到Gitlab的 notes
         handler.add_merge_request_notes(f'Auto Review Result: \n{review_result}')
@@ -177,6 +180,10 @@ def handle_github_push_event(webhook_data: dict, github_token: str, github_url: 
         score = 0
         additions = 0
         deletions = 0
+
+        # 获取项目名称
+        project_name = webhook_data['repository']['name']
+
         if push_review_enabled:
             # 获取PUSH的changes
             changes = handler.get_push_changes()
@@ -188,7 +195,7 @@ def handle_github_push_event(webhook_data: dict, github_token: str, github_url: 
 
             if len(changes) > 0:
                 commits_text = ';'.join(commit.get('message', '').strip() for commit in commits)
-                review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text)
+                review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text, project_name)
                 score = CodeReviewer.parse_review_score(review_text=review_result)
                 for item in changes:
                     additions += item.get('additions', 0)
@@ -196,19 +203,21 @@ def handle_github_push_event(webhook_data: dict, github_token: str, github_url: 
             # 将review结果提交到GitHub的 notes
             handler.add_push_notes(f'Auto Review Result: \n{review_result}')
 
-        event_manager['push_reviewed'].send(PushReviewEntity(
-            project_name=webhook_data['repository']['name'],
-            author=webhook_data['sender']['login'],
-            branch=webhook_data['ref'].replace('refs/heads/', ''),
-            updated_at=int(datetime.now().timestamp()),  # 当前时间
-            commits=commits,
-            score=score,
-            review_result=review_result,
-            url_slug=github_url_slug,
-            webhook_data=webhook_data,
-            additions=additions,
-            deletions=deletions,
-        ))
+        event_manager['push_reviewed'].send(
+            PushReviewEntity(
+                project_name=project_name,
+                author=webhook_data['sender']['login'],
+                branch=webhook_data['ref'].replace('refs/heads/', ''),
+                updated_at=int(datetime.now().timestamp()),  # 当前时间
+                commits=commits,
+                score=score,
+                review_result=review_result,
+                url_slug=github_url_slug,
+                webhook_data=webhook_data,
+                additions=additions,
+                deletions=deletions,
+            )
+        )
 
     except Exception as e:
         error_message = f'服务出现未知错误: {str(e)}\n{traceback.format_exc()}'
@@ -273,7 +282,7 @@ def handle_github_pull_request_event(webhook_data: dict, github_token: str, gith
 
         # review 代码
         commits_text = ';'.join(commit['title'] for commit in commits)
-        review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text)
+        review_result = CodeReviewer().review_and_strip_code(str(changes), commits_text, project_name)
 
         # 将review结果提交到GitHub的 notes
         handler.add_pull_request_notes(f'Auto Review Result: \n{review_result}')

--- a/biz/utils/code_reviewer.py
+++ b/biz/utils/code_reviewer.py
@@ -1,7 +1,7 @@
 import abc
 import os
 import re
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 import yaml
 from jinja2 import Template
@@ -16,11 +16,20 @@ class BaseReviewer(abc.ABC):
 
     def __init__(self, prompt_key: str):
         self.client = Factory().getClient()
-        self.prompts = self._load_prompts(prompt_key, os.getenv("REVIEW_STYLE", "professional"))
+        self.prompts = self._load_prompts(prompt_key)
 
-    def _load_prompts(self, prompt_key: str, style="professional") -> Dict[str, Any]:
+    def _load_prompts(
+        self, prompt_key: str, style: Optional[str] = None, prompt_templates_file: Optional[str] = None
+    ) -> Dict[str, Any]:
         """加载提示词配置"""
-        prompt_templates_file = "conf/prompt_templates.yml"
+        if not style:
+            # 如果未提供, 从环境变量中获取审查风格，默认为 "professional"
+            style = os.getenv("REVIEW_STYLE", "professional")
+
+        if not prompt_templates_file:
+            # 如果未提供, 使用默认的提示词配置文件路径
+            prompt_templates_file = "conf/prompt_templates.yml"
+
         try:
             # 在打开 YAML 文件时显式指定编码为 UTF-8，避免使用系统默认的 GBK 编码。
             with open(prompt_templates_file, "r", encoding="utf-8") as file:


### PR DESCRIPTION
- 项目名称处理优化
  - 在GitLab和GitHub的处理函数中提取项目名称到变量，避免重复访问
  - 为`CodeReviewer.review_and_strip_code`和`CodeReviewer.review_code`方法添加`project_name`参数

- 支持基于项目的自定义提示词配置

- 实现项目级别提示词

  - 避免代码改动过多，同时实现提示词热重载功能，项目级的提示词模板加载都在函数内完成

- 修复了LLM客户端中的异常处理，正确捕获并记录异常信息

