### PR TITLE
fix: issue139:  Retrieve change diffs via Gitaly. from

### DIFF
--- a/biz/gitlab/webhook_handler.py
+++ b/biz/gitlab/webhook_handler.py
@@ -85,7 +85,7 @@ class MergeRequestHandler:
         for attempt in range(max_retries):
             # 调用 GitLab API 获取 Merge Request 的 changes
             url = urljoin(f"{self.gitlab_url}/",
-                          f"api/v4/projects/{self.project_id}/merge_requests/{self.merge_request_iid}/changes")
+                          f"api/v4/projects/{self.project_id}/merge_requests/{self.merge_request_iid}/changes?access_raw_diffs=true")
             headers = {
                 'Private-Token': self.gitlab_token
             }


### PR DESCRIPTION
Retrieve change diffs via Gitaly.

调用 GitLab API 获取 Merge Request 的 changes 超过70个之后diffs 字段值都为空