### PR TITLE
解决GitLab 社区版 9.5.2获取project_id失败的问题

### DIFF
--- a/biz/gitlab/webhook_handler.py
+++ b/biz/gitlab/webhook_handler.py
@@ -185,7 +185,9 @@ class PushHandler:
 
     def parse_push_event(self):
         # 提取 Push 事件的相关参数
-        self.project_id = self.webhook_data.get('project', {}).get('id')
+        self.project_id = self.webhook_data.get('project_id', None)
+        if self.project_id is None:
+            self.project_id = self.webhook_data.get('project', {}).get('id')
         self.branch_name = self.webhook_data.get('ref', '').replace('refs/heads/', '')
         self.commit_list = self.webhook_data.get('commits', [])
 


### PR DESCRIPTION
在使用GitLab 社区版 9.5.2时project_id一直为None
原因是project_id是在消息的外层单独存在，而不是project下面的子项