### PR TITLE
增加二级路由时，pro版本配置

### DIFF
--- a/doc/pro.md
+++ b/doc/pro.md
@@ -72,7 +72,7 @@ services:
     container_name: codereview-mysql
     privileged: true
     environment:
-      MYSQL_ROOT_PASSWORD: Xiongzhun@root
+      MYSQL_ROOT_PASSWORD: u9QdPyXM
       MYSQL_DATABASE: codereview
       TZ: Asia/Shanghai
     command:


### PR DESCRIPTION
原理：通过nginx劫持服务访问并增加路由转发